### PR TITLE
Added HTTP Compression Support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=uy.kohesive.solr
-version=1.8.0-RC-2-SNAPSHOT
+version=1.8.0-RC-3-SNAPSHOT
 
 systemProp.file.encoding=UTF-8
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ version=1.8.0-RC-2-SNAPSHOT
 
 systemProp.file.encoding=UTF-8
 
-version_kotlin=1.2.21
+version_kotlin=1.2.61
 
 version_undertow=1.4.22.Final
 version_solr=7.2.1

--- a/src/main/kotlin/uy/kohesive/solr/undertow/Config.kt
+++ b/src/main/kotlin/uy/kohesive/solr/undertow/Config.kt
@@ -60,6 +60,7 @@ val OUR_PROP_SOLR_WAR_ALLOW_OMIT = "solrWarCanBeOmitted"
 val OUR_PROP_SOLR_VERSION = "solrVersion"
 val OUR_PROP_TEMP_DIR = "tempDir"
 val OUR_PROP_LIBEXT_DIR = "libExtDir"
+val OUR_PROP_HTTP_COMPRESSION = "httpCompression"
 
 
 // system and environment variables that need to be treated the same as our configuration items
@@ -204,6 +205,7 @@ class ServerConfig(private val log: Logger, val loader: ServerConfigLoader) {
     val tempDirSymLinksAllow = configured.value("tempDirSymLinksAllow").asBoolean(false)
     val tempDirSymLinksSafePaths = configured.value("tempDirSymLinksSafePaths").asPathList().map(Path::normalize)
     val solrVersion = configured.value(OUR_PROP_SOLR_VERSION).asString()
+    val httpCompression = configured.value(OUR_PROP_HTTP_COMPRESSION).asBoolean(false);
 
     private val solrWarFileString = configured.value(OUR_PROP_SOLR_WAR).asStringOrNull().nullIfEmpty()
     val solrWarFile: Path? = solrWarFileString?.let { loader.workingDir.resolve(solrWarFileString).normalize() }
@@ -240,6 +242,7 @@ class ServerConfig(private val log: Logger, val loader: ServerConfigLoader) {
         printS(ServerConfig::httpHost)
         printI(ServerConfig::httpIoThreads, 0)
         printI(ServerConfig::httpWorkerThreads, 0)
+        printB(ServerConfig::httpCompression)
 
         printSA(ServerConfig::activeRequestLimits)
 

--- a/src/main/kotlin/uy/kohesive/solr/undertow/SolrUndertow.kt
+++ b/src/main/kotlin/uy/kohesive/solr/undertow/SolrUndertow.kt
@@ -22,6 +22,7 @@ import io.undertow.predicate.Predicates
 import io.undertow.server.HttpHandler
 import io.undertow.server.HttpServerExchange
 import io.undertow.server.handlers.GracefulShutdownHandler
+import io.undertow.server.handlers.encoding.EncodingHandler
 import io.undertow.server.handlers.RequestLimit
 import io.undertow.server.handlers.accesslog.AccessLogHandler
 import io.undertow.server.handlers.accesslog.AccessLogReceiver
@@ -438,7 +439,9 @@ class Server(cfgLoader: ServerConfigLoader) {
         val redirectToAdmin = if (isSolr6) "index.html" else "admin.html"
         val oldAdminUiFixer = Handlers.path(pathHandler).addExactPath(cfg.solrContextPath, Handlers.redirect(cfg.solrContextPath.mustEndWith('/')+redirectToAdmin))
 
-        return ServletDeploymentAndHandler(servletDeploymentMgr, oldAdminUiFixer)
+        val encodingHandler = EncodingHandler.Builder().build(null).wrap(oldAdminUiFixer)
+
+        return ServletDeploymentAndHandler(servletDeploymentMgr, encodingHandler)
     }
 
     private class RequestLimitHelper(private val rlCfg: RequestLimitConfig) {

--- a/src/main/kotlin/uy/kohesive/solr/undertow/SolrUndertow.kt
+++ b/src/main/kotlin/uy/kohesive/solr/undertow/SolrUndertow.kt
@@ -439,9 +439,13 @@ class Server(cfgLoader: ServerConfigLoader) {
         val redirectToAdmin = if (isSolr6) "index.html" else "admin.html"
         val oldAdminUiFixer = Handlers.path(pathHandler).addExactPath(cfg.solrContextPath, Handlers.redirect(cfg.solrContextPath.mustEndWith('/')+redirectToAdmin))
 
-        val encodingHandler = EncodingHandler.Builder().build(null).wrap(oldAdminUiFixer)
-
-        return ServletDeploymentAndHandler(servletDeploymentMgr, encodingHandler)
+        if (cfg.httpCompression) {
+            val encodingHandler = EncodingHandler.Builder().build(null).wrap(oldAdminUiFixer)
+            return ServletDeploymentAndHandler(servletDeploymentMgr, encodingHandler)
+        }
+        else {
+            return ServletDeploymentAndHandler(servletDeploymentMgr, oldAdminUiFixer)
+        }
     }
 
     private class RequestLimitHelper(private val rlCfg: RequestLimitConfig) {


### PR DESCRIPTION
Very minor change, should have no effect on existing users. Setting httpCompression to true in config file will enable standard HTTP compression of servlet responses.